### PR TITLE
[sc-28285] Remove stack trace disclosures from castra exceptions

### DIFF
--- a/src/castra/core.cljs
+++ b/src/castra/core.cljs
@@ -9,6 +9,7 @@
 (ns castra.core
   (:require
     [cognitect.transit :as t]
+    [javelin.core :as j :refer [cell?]]
     [cljsjs.jquery]))
 
 ;; helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -80,12 +81,15 @@
                          (when x (.setItem js/localStorage storage-key x))))
 
 (defn- ajax
-  [{:keys [ajax-fn clj->json json->clj on-error] :as opts} expr]
+  [{:keys [ajax-fn clj->json json->clj on-error additional-headers] :as opts} expr]
   (let [prom    (.Deferred js/jQuery)
         headers (-> {"X-Castra-Csrf"          "true"
                      "X-Castra-Tunnel"        "transit"
                      "X-Castra-Validate-Only" (str (boolean *validate-only*))
                      "Accept"                 "application/transit+json"}
+                    (merge (if (cell? additional-headers)
+                               @additional-headers
+                               additional-headers))
                     (assoc-when "X-Castra-Session" (get-session)))
         body    (if (string? expr) expr (clj->json expr))
         wrap-ex #(make-ex {:message "Server Error" :cause %})


### PR DESCRIPTION
Removes the stack trace from castra exceptions. This is required for security compliance:

- This information might help an attacker gain more information and potentially focus on the development of further attacks for the target system.
- An attacker can understand internal workflow by analyzing stack traces.
- The stack trace can disclose potentially sensitive information such as:
  - physical file paths of relevant files
  - source code fragments
  - version information of various packages
  - database information
  - error messages

Also includes previous work for additional header options related to [sc-14671]